### PR TITLE
add option: `onUncaughtRejection` + log only if no handler

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -182,6 +182,9 @@ function Connection() {
       case 'runtimeException':
         _this._runtimeExceptionCb(m.error)
         break
+      case 'runtimeRejection':
+        _this._runtimeExceptionCb(m.error)
+        break
     }
   })
 }

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -151,7 +151,20 @@ function Connection() {
   this._executeFCb = function() {
   }
 
-  this._runtimeExceptionCb = function() {
+  this._runtimeExceptionCb = function(err) {
+    console.error.apply(null, [
+      new Date().toGMTString().concat(' jailed:sandbox'),
+      'Runtime Exception:',
+      err.stack || err,
+    ])
+  }
+
+  this._runtimeRejectionCb = function(err) {
+    console.error.apply(null, [
+      new Date().toGMTString().concat(' jailed:sandbox'),
+      'Runtime Rejection:',
+      err.stack || err,
+    ])
   }
 
   this._messageHandler = function() {
@@ -183,7 +196,8 @@ function Connection() {
         _this._runtimeExceptionCb(m.error)
         break
       case 'runtimeRejection':
-        _this._runtimeExceptionCb(m.error)
+        // happens when node sends a warning about an uncaught promise failure
+        _this._runtimeRejectionCb(m.error, m.extras)
         break
     }
   })
@@ -192,6 +206,11 @@ function Connection() {
 Connection.prototype.onUncaughtException = function(cb) {
   if ('function' !== typeof cb) throw new TypeError('listener must be a function')
   this._runtimeExceptionCb = cb
+}
+
+Connection.prototype.onUncaughtRejection = function(cb) {
+  if ('function' !== typeof cb) throw new TypeError('listener must be a function')
+  this._runtimeRejectionCb = cb
 }
 
 /**

--- a/lib/Plugin.js
+++ b/lib/Plugin.js
@@ -57,6 +57,9 @@ Plugin.prototype._connect = function() {
   if (this._options.failOnRuntimeError) {
     this._connection.onUncaughtException(this._fCb)
   }
+  if (typeof this._options.onUncaughtRejection === 'function') {
+    this._connection.onUncaughtRejection(this._options.onUncaughtRejection)
+  }
 }
 
 Plugin.prototype._startTimeout = function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jailed-node",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Jailed-Node — flexible JS sandbox (jailed fork)",
   "keywords": [
     "jailed",

--- a/sandbox/sandbox.js
+++ b/sandbox/sandbox.js
@@ -34,6 +34,10 @@ process.on('uncaughtException', function(e) {
   processSend({type: 'runtimeException', error: exportError(e)})
 })
 
+process.on('unhandledRejection', function (e, promise) {
+  processSend({type: 'runtimeRejection', error: exportError(e), promise })
+})
+
 /**
  * Event listener for the plugin message
  */

--- a/sandbox/sandbox.js
+++ b/sandbox/sandbox.js
@@ -30,7 +30,7 @@ function startCheckHeartBeat() {
 }
 
 process.on('uncaughtException', function(e) {
-  //printError('Uncaught Exception:', e.stack || e)
+  printError('Uncaught Exception:', e.stack || e)
   processSend({type: 'runtimeException', error: exportError(e)})
 })
 
@@ -57,7 +57,7 @@ process.on('message', function(data) {
       try {
         conn._messageHandler(m.data);
       } catch (e) {
-        //printError(e.stack);
+        printError(e.stack);
         processSend({type: 'runtimeException', error: exportError(e, m.url)})
       }
       break;
@@ -100,7 +100,7 @@ var importScriptJailed = function(url) {
 function _onImportScript(path) {
   return function(error) {
     if (error) {
-      //printError(error.stack)
+      printError(error.stack)
       processSend({type: 'importFailure', url: path, error: exportError(error, path)})
     } else {
       processSend({type: 'importSuccess', url: path})
@@ -166,7 +166,7 @@ var execute = function(code) {
 
   function onExecute(error) {
     if (error) {
-      //printError(error.stack)
+      printError(error.stack)
       return processSend({type: 'executeFailure', error: exportError(error)})
     }
 
@@ -222,7 +222,7 @@ var loadRemote = function(url, done) {
     if (res.statusCode != 200) {
       var msg = 'Failed to load ' + url + '\n' +
         'HTTP responce status code: ' + res.statusCode
-      //printError(msg)
+      printError(msg)
       done(new Error(msg))
     } else {
       var content = ''

--- a/sandbox/sandbox.js
+++ b/sandbox/sandbox.js
@@ -30,7 +30,7 @@ function startCheckHeartBeat() {
 }
 
 process.on('uncaughtException', function(e) {
-  printError('Uncaught Exception:', e.stack || e)
+  //printError('Uncaught Exception:', e.stack || e)
   processSend({type: 'runtimeException', error: exportError(e)})
 })
 
@@ -57,7 +57,7 @@ process.on('message', function(data) {
       try {
         conn._messageHandler(m.data);
       } catch (e) {
-        printError(e.stack);
+        //printError(e.stack);
         processSend({type: 'runtimeException', error: exportError(e, m.url)})
       }
       break;
@@ -100,7 +100,7 @@ var importScriptJailed = function(url) {
 function _onImportScript(path) {
   return function(error) {
     if (error) {
-      printError(error.stack)
+      //printError(error.stack)
       processSend({type: 'importFailure', url: path, error: exportError(error, path)})
     } else {
       processSend({type: 'importSuccess', url: path})
@@ -166,7 +166,7 @@ var execute = function(code) {
 
   function onExecute(error) {
     if (error) {
-      printError(error.stack)
+      //printError(error.stack)
       return processSend({type: 'executeFailure', error: exportError(error)})
     }
 
@@ -222,7 +222,7 @@ var loadRemote = function(url, done) {
     if (res.statusCode != 200) {
       var msg = 'Failed to load ' + url + '\n' +
         'HTTP responce status code: ' + res.statusCode
-      printError(msg)
+      //printError(msg)
       done(new Error(msg))
     } else {
       var content = ''


### PR DESCRIPTION
This was a useful update to track uncaught promise rejections from async code that was running in my jailed sandbox.

Feel free to merge if you want!